### PR TITLE
fix odd team calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/taskmedia/roundrobintournament
 
 go 1.13
+
+require github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/roundrobintournament.go
+++ b/roundrobintournament.go
@@ -1,34 +1,27 @@
 package roundrobintournament
 
+import (
+	"github.com/google/uuid"
+)
+
 // GenerateRoundRobinTournamentMatches generates a 2d slice of matches of a single round robin tournament.
 // Each team will play one time against all other teams.
 func GenerateRoundRobinTournamentMatches(teams []string) [][]string {
 	matches := make([][]string, 0)
 
+	dummy := "even"
+	if len(teams)%2 != 0 {
+		dummy = uuid.New().String()
+		teams = append(teams, dummy)
+	}
+
 	rotation := make([]string, len(teams))
 	copy(rotation, teams)
 
-	var cachedTeam string
-
 	for i := 0; i < (len(teams) - 1); i++ {
 		rotationLen := len(rotation)
-
-		if len(teams)%2 == 0 {
-			// number of teams is even - cachedTeam is not required
-			for i := 0; i < len(rotation); i = i + 2 {
-				matches = append(matches, []string{rotation[i], rotation[i+1]})
-			}
-		} else {
-			// number of teams is odd - cachedTeam is required
-			for i := 0; i < len(rotation)-1; i = i + 2 {
-				matches = append(matches, []string{rotation[i], rotation[i+1]})
-				if cachedTeam != "" {
-					matches = append(matches, []string{cachedTeam, rotation[i+2]})
-					cachedTeam = ""
-				} else {
-					cachedTeam = rotation[i+2]
-				}
-			}
+		for i := 0; i < len(rotation); i = i + 2 {
+			matches = append(matches, []string{rotation[i], rotation[i+1]})
 		}
 
 		// rotate teams for next round
@@ -39,5 +32,27 @@ func GenerateRoundRobinTournamentMatches(teams []string) [][]string {
 		rotation = rotationHelper
 	}
 
+	// remove dummy matches
+	if dummy != "even" {
+		i := 0
+		for _, x := range matches {
+			if !stringSlicecontains(x, dummy) {
+				matches[i] = x
+				i++
+			}
+		}
+		matches = matches[:i]
+	}
+
 	return matches
+}
+
+// Iterate over slice of string  to check whether it an element or not
+func stringSlicecontains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/roundrobintournament_test.go
+++ b/roundrobintournament_test.go
@@ -23,8 +23,8 @@ func TestGenerateRoundRobinTournamentMatches3Teams(t *testing.T) {
 
 	expectedmatches := [][]string{
 		{"TeamA", "TeamB"},
+		{"TeamB", "TeamC"},
 		{"TeamA", "TeamC"},
-		{"TeamC", "TeamB"},
 	}
 
 	if !slicesEqual(expectedmatches, matches) {


### PR DESCRIPTION
The calculation for a odd number of teams was not correct for more than 3 teams (5,7,...).
This fixes the algorithm by adding a dummy team (generated uuid) and removing its matches it afterwards.

fixes #4