### PR TITLE
add posibility to generate matches by number

### DIFF
--- a/roundrobintournament.go
+++ b/roundrobintournament.go
@@ -1,12 +1,15 @@
 package roundrobintournament
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 )
 
 // GenerateRoundRobinTournamentMatches generates a 2d slice of matches of a single round robin tournament.
 // Each team will play one time against all other teams.
-func GenerateRoundRobinTournamentMatches(teams []string) [][]string {
+func GenerateRoundRobinTournamentMatchesByTeams(teams []string) [][]string {
+
 	matches := make([][]string, 0)
 
 	dummy := "even"
@@ -55,4 +58,13 @@ func stringSlicecontains(s []string, e string) bool {
 		}
 	}
 	return false
+}
+
+func GenerateRoundRobinTournamentMatchesByNumber(numberTeams int) [][]string {
+	teams := make([]string, 0)
+	for i := 1; i <= numberTeams; i++ {
+		teams = append(teams, fmt.Sprintf("Team %d", i))
+	}
+
+	return GenerateRoundRobinTournamentMatchesByTeams(teams)
 }

--- a/roundrobintournament_test.go
+++ b/roundrobintournament_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 // testing odd teams number
-func TestGenerateRoundRobinTournamentMatches3Teams(t *testing.T) {
+func TestGenerateRoundRobinTournamentMatchesByTeams3Teams(t *testing.T) {
 	teams := []string{
 		"TeamA",
 		"TeamB",
 		"TeamC",
 	}
 
-	matches := GenerateRoundRobinTournamentMatches(teams)
+	matches := GenerateRoundRobinTournamentMatchesByTeams(teams)
 
 	expectedLenMatches := expectedMatches(len(teams))
 
@@ -33,7 +33,7 @@ func TestGenerateRoundRobinTournamentMatches3Teams(t *testing.T) {
 }
 
 // testing even teams number
-func TestGenerateRoundRobinTournamentMatches4Teams(t *testing.T) {
+func TestGenerateRoundRobinTournamentMatchesByTeams4Teams(t *testing.T) {
 	teams := []string{
 		"TeamA",
 		"TeamB",
@@ -41,7 +41,7 @@ func TestGenerateRoundRobinTournamentMatches4Teams(t *testing.T) {
 		"TeamD",
 	}
 
-	matches := GenerateRoundRobinTournamentMatches(teams)
+	matches := GenerateRoundRobinTournamentMatchesByTeams(teams)
 
 	expectedLenMatches := expectedMatches(len(teams))
 
@@ -64,13 +64,13 @@ func TestGenerateRoundRobinTournamentMatches4Teams(t *testing.T) {
 }
 
 // testing large number of even teams
-func TestGenerateRoundRobinTournamentMatches10Teams(t *testing.T) {
+func TestGenerateRoundRobinTournamentMatchesByTeams10Teams(t *testing.T) {
 	teams := make([]string, 0)
 	for i := 1; i <= 10; i++ {
 		teams = append(teams, fmt.Sprintf("Team %d", i))
 	}
 
-	matches := GenerateRoundRobinTournamentMatches(teams)
+	matches := GenerateRoundRobinTournamentMatchesByTeams(teams)
 
 	expectedLenMatches := expectedMatches(len(teams))
 
@@ -80,19 +80,44 @@ func TestGenerateRoundRobinTournamentMatches10Teams(t *testing.T) {
 }
 
 // testing large number of odd teams
-func TestGenerateRoundRobinTournamentMatches11Teams(t *testing.T) {
+func TestGenerateRoundRobinTournamentMatchesByTeams11Teams(t *testing.T) {
 	teams := make([]string, 0)
 	for i := 1; i <= 11; i++ {
 		teams = append(teams, fmt.Sprintf("Team %d", i))
 	}
 
-	matches := GenerateRoundRobinTournamentMatches(teams)
+	matches := GenerateRoundRobinTournamentMatchesByTeams(teams)
 
 	expectedLenMatches := expectedMatches(len(teams))
 
 	if len(matches) != expectedLenMatches {
 		t.Fatalf("Length of matches (%d) not as expected (%d)", len(matches), expectedLenMatches)
 	}
+}
+
+func TestGenerateRoundRobinTournamentMatchesByNumberEven(t *testing.T) {
+	teamSize := 14
+
+	matches := GenerateRoundRobinTournamentMatchesByNumber(teamSize)
+
+	expectedLenMatches := expectedMatches(teamSize)
+
+	if len(matches) != expectedLenMatches {
+		t.Fatalf("Length of matches (%d) not as expected (%d)", len(matches), expectedLenMatches)
+	}
+}
+
+func TestGenerateRoundRobinTournamentMatchesByNumberOdd(t *testing.T) {
+	teamSize := 15
+
+	matches := GenerateRoundRobinTournamentMatchesByNumber(teamSize)
+
+	expectedLenMatches := expectedMatches(teamSize)
+
+	if len(matches) != expectedLenMatches {
+		t.Fatalf("Length of matches (%d) not as expected (%d)", len(matches), expectedLenMatches)
+	}
+
 }
 
 // calculates the expected number of matches by a given team length


### PR DESCRIPTION
this will enable you to automatically generate dummy teams and not specify teamnames.

breaking changes: renamed `GenerateRoundRobinTournamentMatches` to `GenerateRoundRobinTournamentMatchesByTeams`

closes #3